### PR TITLE
Added OutDir, changed default arch, and bug fix.

### DIFF
--- a/Public/New-EXEFromPS1.ps1
+++ b/Public/New-EXEFromPS1.ps1
@@ -30,13 +30,16 @@
     .PARAMETER KeepTempDir
         Keep the temp directory around after the exe is created. It is available at the root of C:.
 
-    .PARAMETER x64
-        Use the 64-bit iexpress path so that 64-bit PowerShell is consequently called.
+    .PARAMETER x86
+        Use the 32-bit iexpress path so that 32-bit PowerShell is consequently called.
 		
 	.PARAMETER SigningCertificate
         Sign all PowerShell scripts and subsequent executable with the defined certificate.
         Expected format of Cert:\CurrentUser\My\XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-		
+	
+	.PARAMETER OutputDirectory
+    Move the completed executable to the defined directory.
+	
     .OUTPUTS
         An exe file in the same directory as the ps1 script you specify
 
@@ -56,7 +59,8 @@
 
     .NOTES
         Created by Nick Rodriguez
-
+		Modified by Etcha-Sketch - Added PKI signature support for script and executables and added output directory functionality. Changed default architecture to x64
+		
         Requires iexpress, which is included in most versions of Windows (https://en.wikipedia.org/wiki/IExpress).
 
     #>
@@ -106,29 +110,38 @@
 
         [Parameter(Mandatory=$false)]
         [switch]
-        $x64,
+        $x86,
 		
         [Parameter(Mandatory=$false)]
         [ValidateScript({
-                  if (Test-Path $_) {
+            if (Test-Path $_) {
         		if ((Get-Item $_).HasPrivateKey -ne $true) {
         			throw "[$_] You do not have the corresponding private key to sign with this certificate."
-        		} else { $true }
+                } else { $true }
         	}
         	else {
         		throw "[$_] Cannot find the certificate."
-        	}
-              })]
-              [string]
-              $SigningCertificate
+            }
+        })]
+        [string]
+        $SigningCertificate,
+
+		[Parameter(Mandatory=$false)]
+		[ValidateScript({
+			if (-not (Get-Item $_).PSIsContainer) {
+				throw "[$_] is not a directory."
+			} else { $true }
+		})]
+		[string]
+		$OutputDirectory
     )
 
     begin {
-        # use 32-bit iexpress for wider compatibility unless user specifies otherwise
-        if ($x64) {
-            $IExpress = "C:\WINDOWS\System32\iexpress"
-        } else {
+        # use 64-bit iexpress as everything should be 64-bit by now, you can specify -x86 for compatibility reasons.
+        if ($x86) {
             $IExpress = "C:\WINDOWS\SysWOW64\iexpress"
+        } else {
+            $IExpress = "C:\WINDOWS\System32\iexpress"
         }
     }
 
@@ -145,14 +158,14 @@
         Write-Verbose "PowerShell script selected: $PSScriptPath"
 
         # If signing certificate defined, generate objects to be used to sign subsequent scrips/executables.
-		if ($SigningCertificate -ne $null) {
-			Write-Verbose "Signing Certificate defined, will detect and sign any unsigned supplemental PowerShell scripts and final executable."
+		if (($SigningCertificate -ne "") -and ($SigningCertificate -ne $null)) {
+			$SignFiles = $true
+            Write-Verbose "Signing Certificate defined, will detect and sign any unsigned supplemental PowerShell scripts and final executable."
 			$certificateobject = Get-Item $SigningCertificate
 			$certificatethumb = $certificateobject.Thumbprint
-			$SignFiles = $true
 		} else {
-			$SignFiles = $false
-		}
+            $SignFiles = $false
+        }
 		
 		# Name of the extensionless target, replace spaces with underscores
         $Target = ($PSScriptName -replace '.ps1', '') -replace " ", '_'
@@ -310,28 +323,47 @@
 		}
 
         # If creating 64-bit exe, append to name to clarify
-        if ($x64) {
-            $EXE = "$ScriptRoot\$Target (x64).exe"
+        if ($x86) {
+            $EXE = "$ScriptRoot\$Target (x86).exe"
         } else {
-            $EXE = "$ScriptRoot\$Target.exe"
+            $EXE = "$ScriptRoot\$Target (x64).exe"
         }
 		
 		# Determine if the EXE target already exists, and if it does prompt the user on how to continue.
-		if (Test-Path $EXE) {
-			Write-Output "$($EXE) already exists, would you like to replace it?"
-			$ClearExisting = Read-Host "[y]/n"
-			if (($ClearExisting.ToUpper()) -eq 'N') {
-				Write-Host "Please re-run after you have cleaned up the destination directory." -ForegroundColor Red
-				Start-sleep -seconds 30
-				Remove-Item $Temp -Recurse -Force 
-				break
-			} else {
-				Remove-item $EXE -Force | Out-Null
+		if (($OutputDirectory -eq $null) -or ($OutputDirectory -eq "")) {
+			if (Test-Path $EXE) {
+				Write-Output "$($EXE) already exists, would you like to replace it?"
+				$ClearExisting = Read-Host "[y]/n"
+				if (($ClearExisting.ToUpper()) -eq 'N') {
+					Write-Host "Please re-run after you have cleaned up the destination directory." -ForegroundColor Red
+					Start-sleep -seconds 30
+					Remove-Item $Temp -Recurse -Force 
+					break
+				} else {
+					Remove-item $EXE -Force | Out-Null
+				}
+			}
+			$FinalOutputEXE = $EXE
+		} else {
+			$FinalOutputEXE = "$($OutputDirectory)\$($EXE.split('\')[-1])"
+			if (Test-Path $EXE) {
+				$EXE = $EXE.replace(".exe","-$(Get-Random -Minimum 1000000000 -Maximum 9999999999).exe")
+			}
+			if (Test-Path $FinalOutputEXE) {
+				Write-Output "$($FinalOutputEXE) already exists, would you like to replace it?"
+				$ClearExisting = Read-Host "[y]/n"
+				if (($ClearExisting.ToUpper()) -eq 'N') {
+					Write-Host "Please re-run after you have cleaned up the destination directory." -ForegroundColor Red
+					Start-sleep -seconds 30
+					Remove-Item $Temp -Recurse -Force 
+					break
+				} else {
+					Remove-item $FinalOutputEXE -Force | Out-Null
+				}	
 			}
 		}
+		Write-Verbose "Target EXE: $FinalOutputEXE"
 		
-        Write-Verbose "Target EXE: $EXE"
-
         # create the sed file used by iexpress
         $SED = "$Temp\$Target.sed"
         New-Item $SED -ItemType File -Force | Out-Null
@@ -426,7 +458,14 @@
 		# Sign the final executable with the declared certificate if defined.
 		if ($SignFiles) {
 			Write-Verbose "Signing $($EXE) with certificate thumb print: $($certificatethumb)."
-			Set-AuthenticodeSignature -Certificate $certificateobject -FilePath $EXE | Out-Null
+			try {
+				Set-AuthenticodeSignature -Certificate $certificateobject -FilePath $EXE | Out-Null
+			} catch {
+				# Very rarely the system will try to sign the script too fast and will not be able to access the file.
+				Write-verbose "Signing $($EXE) too fast, waiting 5 seconds and trying again."
+				start-sleep -seconds 5
+				Set-AuthenticodeSignature -Certificate $certificateobject -FilePath $EXE | Out-Null
+			}
 			# Ensure the script is signed successfully with the Thumbprint
 			if ((((Get-AuthenticodeSignature -FilePath $EXE).SignerCertificate).Thumbprint) -ne $certificatethumb) {
 				Write-verbose "Signing $($EXE) failed"
@@ -434,6 +473,12 @@
 				Write-verbose "$($EXE) signing successful."
 			}
 			
+		}
+		
+		if (!(($OutputDirectory -eq $null) -or ($OutputDirectory -eq ""))) {
+			Start-Sleep -Milliseconds 250
+			Write-Verbose "Moving the final executable to $($FinalOutputEXE)"
+			Move-item $EXE $FinalOutputEXE -Force
 		}
 		
         # Clean up unless user specified not to

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ If blank, you will be prompted with a file browse dialog where you can select a 
 
 **KeepTempDir** - Keep the temp directory around after the exe is created. It is available at the root of C:.
 
-**x64** - Use the 64-bit iexpress path so that 64-bit PowerShell is consequently called.
+**x86** - Use the 32-bit iexpress path so that 32-bit PowerShell is consequently called. Intended for compatibility with older devices.
 
 **SigningCertificate** - Sign all PowerShell scripts and subsequent executable with the defined certificate. Expected format of Cert:\CurrentUser\My\XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+**OutputDirectory** - Move the completed executable to the defined directory.
 
 ### Examples
 ```
@@ -44,6 +46,11 @@ New-EXEFromPS1 -SupplementalDirectoryPath 'C:\Temp\MyTestDir' -KeepTempDir
 # Zips MyTestDir and attaches it to the exe. When the exe is run, but before the user's script gets run, 
 # it will be extracted to the same directory as the user's script. Temp directory used during exe creation
 # will be left intact for user inspection or debugging purposes.
+
+New-EXEFromPS1 -SelectSupplementalFiles -x86 -SigningCertificate Cert:\CurrentUser\My\XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -OutputDirectory $env:userprofile\Desktop
+# Prompts the user to select the PowerShell script and supplemental files using an Open File Dialog. Creates a 32-bit application using the 32-bit iexpress binary.
+# If the defined script or supplemental files are PowerShell scripts they will be signed with the defined certificate. Once the executable is generated it will also
+# be signed and moved to the specified output directory.
 ```
 
 ## Issues


### PR DESCRIPTION
Added and OutputDirectory parameter to allow for the final executable to be stored elsewhere from the PSScriptPath.

Changed the default architecture support to x64 and changed all references to the -x64 parameter to -x86  for compatibility as most devices should be running 64 bit versions of Windows by now.

Fixed Incorrect Cast of $SignFiles
The parameter $SigningCertificate was used to detect if the user had defined a certificate to sign scripts and the final executable with. If the script detected that the $SigningCertificate variable was null it would skip signing for the rest of the script. Unfortunately this introduced a slight bug as when the user does not specify a signing certificate, the $SigningCertificate variable is actually a null string rather then being completely null. The tool would still work fine and output the executable as desired, but the verbose screen would be clogged with failed signing attempts. This is fixed by checking the variable to be a non-null string and not a null value.